### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ logo: /assets/img/logo.png
 description: A collection of tutorials for CellProfiler. Other resources linked below.
 markdown: kramdown
 favicon: true
+color-scheme: light
 
 platforms:
   - name: YouTube Playlist


### PR DESCRIPTION
By default, the Jekyll theme uses an auto color scheme i.e. auto light/dark mode.

Since the background color is being overwritten to #f3f3f3
Adding this color scheme makes sure that all the styles are being used as per the light mode colors.