### PR TITLE
fix(pipeline): default file/folder naming to 'No'

### DIFF
--- a/3DFISHinCelegans/NewFishPureCP.cppipe
+++ b/3DFISHinCelegans/NewFishPureCP.cppipe
@@ -1,6 +1,6 @@
 CellProfiler Pipeline: http://www.cellprofiler.org
 Version:5
-DateRevision:421
+DateRevision:428
 GitHash:
 ModuleCount:20
 HasImagePlaneDetails:False
@@ -251,7 +251,7 @@ SaveImages:[module_num:19|svn_version:'Unknown'|variable_revision_number:16|show
 ExportToSpreadsheet:[module_num:20|svn_version:'Unknown'|variable_revision_number:13|show_window:True|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
     Select the column delimiter:Comma (",")
     Add image metadata columns to your object data file?:No
-    Add image file and folder names to your object data file?:Yes
+    Add image file and folder names to your object data file?:No
     Select the measurements to export:Yes
     Calculate the per-image mean values for object measurements?:No
     Calculate the per-image median values for object measurements?:No

--- a/internal_use/docs/source/3DNuclei/Nuclei3DTimeConsumingPipeline.md
+++ b/internal_use/docs/source/3DNuclei/Nuclei3DTimeConsumingPipeline.md
@@ -19,8 +19,6 @@ and the clustering of their nuclei in 3D cell culture.
 
 Voxel dimensions: 0.124x0.124x0.200 um
 
-Calibration Image: Voxel dimensions: 1x1x1 um
-
 ## **Importing data in CellProfiler**
 
 1. Highlight the **Images** module.
@@ -56,8 +54,7 @@ always a good practice to check if everything is fine.
 
 
 >The relative pixel spacing was provided and is 0.124 um in x and y and
-0.200 um in z. To run the calibration file please change the relative
-pixel spacing to 1x1x1 um.
+0.200 um in z.
 
 6. Assign the images “variable names” that describe the contents in the image. For example, use the name "Nuclei", "DNA", “DAPI” or something else that will remind you what the image is.
 7. Hit the "update" button to populate

--- a/internal_use/docs/source/QualityControl/BBBC022_QualityControlExercise.md
+++ b/internal_use/docs/source/QualityControl/BBBC022_QualityControlExercise.md
@@ -211,7 +211,7 @@ in later steps.
   different/smaller subset or delete it altogether by using the Gate
   Inspector (‘gate’-> ‘MANAGE GATES’).
 
-## 4. **Optional- use the PlateViewer tool to check for other features to gate on (~10 minutes)**
+## 4. **Optional — use the PlateViewer tool to check for other features to gate on (~10 minutes)**
 
 If you want to see if you can find additional features that might distinguish good
 images from bad images, feel free to explore the feature set more thoroughly.

--- a/internal_use/docs/source/QualityControl/BBBC022_QualityControlExercise.md
+++ b/internal_use/docs/source/QualityControl/BBBC022_QualityControlExercise.md
@@ -204,7 +204,7 @@ in later steps.
 *Figure 1: Examining the objects inside a gate.*
 ```
 
-- Look at some of the images inside the gate ( you may need to click
+- Look at some of the images inside the gate (you may need to click
   ‘Show controls’ to adjust the zoom, contrast stretch, etc). Are they
   in focus, and are they free of bright debris? If they seem all or
   mostly like they’re high quality, adjust the gate to look at a

--- a/internal_use/docs/source/UnmixColorsTutorial/UnmixColorsTutorial.md
+++ b/internal_use/docs/source/UnmixColorsTutorial/UnmixColorsTutorial.md
@@ -38,8 +38,7 @@ absorbance in the Custom mode.
 
 ## **Materials necessary for this exercise:**
 
-- Histopathological image of parathyroid adenoma. Hematoxylin and eosin
-  : stain in a slide.
+- Histopathological image of parathyroid adenoma. Hematoxylin and eosin: stain in a slide.
 
 **Example 1:** Parathyroid Adenoma
 <br>


### PR DESCRIPTION
This PR sets the default for file/folder naming prompts to “No” in the pipeline export step, harmonizing the pipeline behavior with the tutorial instructions.